### PR TITLE
improvements to rotating bulk logger

### DIFF
--- a/messageflux/logging/bulk_rotating_device_handler.py
+++ b/messageflux/logging/bulk_rotating_device_handler.py
@@ -47,7 +47,7 @@ class BulkRotatingDeviceHandler(BulkRotatingHandlerBase):
         self._output_device = self._output_device_manager.get_output_device(name=self._output_device_name)
         self._metadata = metadata or {}
         self._queue: queue.Queue = queue.Queue()
-        self._wait_on_queue_timeout = max(wait_on_queue_timeout, 1)
+        self._wait_on_queue_timeout = max(wait_on_queue_timeout, 0.1)
         self._send_to_device_thread: Optional[Thread] = None
 
         super(BulkRotatingDeviceHandler, self).__init__(live_log_path=live_log_path,

--- a/messageflux/logging/bulk_rotating_device_handler.py
+++ b/messageflux/logging/bulk_rotating_device_handler.py
@@ -57,7 +57,9 @@ class BulkRotatingDeviceHandler(BulkRotatingHandlerBase):
                                                         live_log_prefix=live_log_prefix)
 
     def _do_send_to_device_thread(self):
-        assert self._queue is not None
+        if self._queue is None:
+            self._queue = queue.Queue()
+
         while self._run:
             try:
                 file_to_send = self._queue.get(timeout=self._wait_on_queue_timeout)

--- a/messageflux/logging/bulk_rotating_device_handler.py
+++ b/messageflux/logging/bulk_rotating_device_handler.py
@@ -1,7 +1,6 @@
 import os
 import queue
 import traceback
-from queue import Queue
 from threading import Thread
 from typing import Optional, Dict, Any
 
@@ -38,7 +37,8 @@ class BulkRotatingDeviceHandler(BulkRotatingHandlerBase):
         :param max_time: the maximum time (in seconds) to wait before rotation
         :param live_log_prefix: the prefix for live log file
         :param wait_on_queue_timeout: the timeout in seconds to wait for the publish queue to have messages.
-        must be greater then 0. lower number will make the thread busy wait. higher number will take more time to kill thread when close is called
+        must be greater then 0. lower number will make the thread busy wait.
+        higher number will take more time to kill thread when close is called
         """
         self._output_device_manager = output_device_manager
         self._output_device_name = output_device_name
@@ -46,7 +46,7 @@ class BulkRotatingDeviceHandler(BulkRotatingHandlerBase):
         self._output_device_manager.connect()
         self._output_device = self._output_device_manager.get_output_device(name=self._output_device_name)
         self._metadata = metadata or {}
-        self._queue = Queue()
+        self._queue: queue.Queue = queue.Queue()
         self._wait_on_queue_timeout = max(wait_on_queue_timeout, 1)
         self._send_to_device_thread: Optional[Thread] = None
 


### PR DESCRIPTION
* made the rotating handler release the lock sooner
* made the rotating device handler, send to device on a different thread, so it won't block the logging while rotating